### PR TITLE
New 'auto' view that updates an existing entry else creates it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,10 @@ In ``<project>/views/rest.py``:
     def obj_update(request):
         return obj.update(request)
 
+    @view_config(route_name='obj_auto')
+    def obj_auto(request):
+        return obj.auto(request)
+
     @view_config(route_name='obj_delete', renderer='jsonp')
     def obj_delete(request):
         return obj.delete(request)
@@ -137,7 +141,7 @@ Build::
 Protocol
 --------
 
-Read many, ``GET`` on ``.../obj``:
+* Read many, ``GET`` on ``.../obj``:
 
 .. code:: javascript
 
@@ -151,7 +155,7 @@ Read many, ``GET`` on ``.../obj``:
         ]
     }
 
-Read one, ``GET`` on ``.../obj/{id}``:
+* Read one, ``GET`` on ``.../obj/{id}``:
 
 .. code:: javascript
 
@@ -161,13 +165,13 @@ Read one, ``GET`` on ``.../obj/{id}``:
         ...
     }
 
-Count, ``GET`` on ``.../obj/count``:
+* Count, ``GET`` on ``.../obj/count``:
 
 .. code:: javascript
 
     23
 
-Create, ``POST`` on ``.../obj`` with data:
+* Create, ``POST`` on ``.../obj`` with data:
 
 .. code:: javascript
 
@@ -178,7 +182,7 @@ Create, ``POST`` on ``.../obj`` with data:
 
 and it will return the id.
 
-Update, ``PUT`` on ``.../obj/{id}`` with data:
+* Update, ``PUT`` on ``.../obj/{id}`` with data:
 
 .. code:: javascript
 
@@ -187,4 +191,17 @@ Update, ``PUT`` on ``.../obj/{id}`` with data:
         ...
     }
 
-Delete, ``DELETE`` on ``.../obj/{id}``.
+* Auto, ``POST`` on ``.../obj/auto`` with data:
+
+.. code:: javascript
+
+    {
+        "id": id,
+        "property": "value",
+        ...
+    }
+
+If an object matches the given id, it will be updated, else a new object is
+automatically created with the given id value.
+
+* Delete, ``DELETE`` on ``.../obj/{id}``.


### PR DESCRIPTION
This PR adds a new view named "auto" that gets the item id from the attributes (if missing a 400 error is returned), if an existing item matches it is updated with the provided values, else a new item is created. Request is submitted using POST method.

Example usage:

```
inventaire = REST(DBSession, Inventaire)

@view_config(route_name='inventaire_auto', renderer='jsonp')
def inventaire_auto(request):
    return inventaire.auto(request)
```

URLs and request body:

```
POST http://host/main/wsgi/inventaire/auto
{
    "designation": "Portable Dell",
    "equipement_id": 10002814,
    "classe": "Printer",
    "local": "PB 1234",
    "centre_cout": 49,
    "fabricant": "ARP Datacon"
}
```
