### PR TITLE
Manage not iterable relationships + support of additional properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,23 @@ In ``<project>/__init__.py``:
     config.add_renderer('jsonp', JSONP(param_name='callback'))
     add_rest_routes(config, 'obj', '/object')
 
+Additional properties
+---------------------
+
+It is possible to add some extra properties by defining in the model an
+``__additional_properties__`` function. For instance:
+
+.. code:: python
+
+    class Object(Base):
+
+        @property
+        def __additional_properties__(self):
+            l10n = {}
+            for l in self.l10n:
+                l10n[l.lang.code] = l.value
+            return { "l10n": l10n } 
+
 Using Relationships
 -------------------
 

--- a/c2c/sqlalchemy/rest/__init__.py
+++ b/c2c/sqlalchemy/rest/__init__.py
@@ -72,10 +72,15 @@ class REST(object):
         properties[self.id] = getattr(obj, self.id)
         for key in self.relationships:
             rel = self.relationships[key]
-            data = [rel['rest']._properties(o) for o in getattr(obj, key)]
+            attr = getattr(obj, key)
+            if hasattr(attr, '__iter__'):
+                data = [rel['rest']._properties(o) for o in attr]
+            else:
+                data = rel['rest']._properties(attr)
             propname = rel['propname'] if 'propname' in rel else key
             properties[propname] = data
-            
+        if hasattr(obj, '__additional_properties__'):
+            properties.update(obj.__additional_properties__)
         return properties
 
     def read_many(self, request):


### PR DESCRIPTION
With this PR:
- not iterable relationships are correctly handled
- it is possible to specify some extra properties in an `__additional_properties__``function in the model. For instance:

```
    class Object(Base):

        @property
        def __additional_properties__(self):
            l10n = {}
            for l in self.l10n:
                l10n[l.lang.code] = l.value
            return { "l10n": l10n } 
```
